### PR TITLE
Bookings index

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -1,6 +1,12 @@
 class BookingsController < ApplicationController
   def index
     @bookings = Booking.all
+    @renter_bookings = []
+    @bookings.each do |booking|
+        if booking.outfit.user.id == current_user.id
+          @renter_bookings << booking
+        end
+      end
   end
 
   def show

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -7,6 +7,13 @@ class BookingsController < ApplicationController
           @renter_bookings << booking
         end
       end
+
+    @rentee_bookings = []
+    @bookings.each do |booking|
+      if booking.user.id == current_user.id
+        @rentee_bookings << booking
+      end
+    end
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
 
   has_many :outfits
   has_many :bookings
+
 end

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -1,16 +1,17 @@
 <% if @renter_bookings.any? %>
-  <h2>Your pending booking requests:</h2>
-  <p>These requests to book your outfits are awaiting an answer!</p>
+
 
   <div>
     <% @renter_bookings.each do |booking| %>
       <% if booking.status == "pending" %>
-      <h3><%= booking.outfit.title %></h3>
-      <p>Booking status: <%= booking.status %></p>
-      <p><%= booking.start_date %> - <%= booking.end_date %></p>
-          <a href="#">Accept</a>
-          <a href="#">Decline</a>
-        <% end %>
+        <h2>Your pending booking requests:</h2>
+        <p>These requests to book your outfits are awaiting an answer!</p>
+        <h3><%= booking.outfit.title %></h3>
+        <p>Booking status: <%= booking.status %></p>
+        <p><%= booking.start_date %> - <%= booking.end_date %></p>
+            <a href="#">Accept</a>
+            <a href="#">Decline</a>
+      <% end %>
     <% end %>
   </div>
 

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -1,13 +1,27 @@
-<h1>Bookings Requests</h1>
+<% if @renter_bookings.any? %>
+  <h2>Your pending booking requests:</h2>
+  <p>These requests to book your outfits are awaiting an answer!</p>
 
-<div>
-  <% @bookings.each do |booking| %>
-    <h3><%= booking.outfit.title %></h3>
-    <p>Booking status: <%= booking.status %></p>
-    <p><%= booking.start_date %> - <%= booking.end_date %></p>
-      <% if booking.status == "pending" %>
-        <a href="#">Accept</a>
-        <a href="#">Decline</a>
-      <% end %>
+  <div>
+    <% @renter_bookings.each do |booking| %>
+      <h3><%= booking.outfit.title %></h3>
+      <p>Booking status: <%= booking.status %></p>
+      <p><%= booking.start_date %> - <%= booking.end_date %></p>
+        <% if booking.status == "pending" %>
+          <a href="#">Accept</a>
+          <a href="#">Decline</a>
+        <% end %>
+    <% end %>
+  </div>
+
+  <% @renter_bookings.each do |book| %>
+    <% if  booking.status == "accepted" %>
+      <h2>Confirmed booking requests for your outfits:</h2>
+      <h5><%= booking.outfit.title %></h5>
+      <p><%= booking.start_date %> - <%= booking.end_date %></p>
+    <% end %>
   <% end %>
-</div>
+
+<% else %>
+  <h2>You have no booking requests!</h2>
+<% end %>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -14,7 +14,7 @@
     <% end %>
   </div>
 
-  <% @renter_bookings.each do |book| %>
+  <% @renter_bookings.each do |booking| %>
     <% if  booking.status == "accepted" %>
       <h2>Confirmed booking requests for your outfits:</h2>
       <h5><%= booking.outfit.title %></h5>
@@ -24,4 +24,19 @@
 
 <% else %>
   <h2>You have no booking requests!</h2>
+<% end %>
+
+<% if @rentee_bookings.any? %>
+  <h2>Your booked outfits</h2>
+  <p>Your pet is going to be the next big Instagram star with these...</p>
+
+  <div>
+    <% @rentee_bookings.each do |booking| %>
+      <h3><%= booking.outfit.title %></h3>
+      <p>Booking status: <%= booking.status %></p>
+      <p><%= booking.start_date %> - <%= booking.end_date %></p>
+    <% end %>
+  </div>
+<% else %>
+  <h2>You have no upcoming outfits</h2>
 <% end %>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -4,10 +4,10 @@
 
   <div>
     <% @renter_bookings.each do |booking| %>
+      <% if booking.status == "pending" %>
       <h3><%= booking.outfit.title %></h3>
       <p>Booking status: <%= booking.status %></p>
       <p><%= booking.start_date %> - <%= booking.end_date %></p>
-        <% if booking.status == "pending" %>
           <a href="#">Accept</a>
           <a href="#">Decline</a>
         <% end %>
@@ -15,7 +15,7 @@
   </div>
 
   <% @renter_bookings.each do |booking| %>
-    <% if  booking.status == "accepted" %>
+    <% if booking.status == "accepted" %>
       <h2>Confirmed booking requests for your outfits:</h2>
       <h5><%= booking.outfit.title %></h5>
       <p><%= booking.start_date %> - <%= booking.end_date %></p>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_30_183315) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_01_150907) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,6 +66,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_30_183315) do
     t.datetime "updated_at", null: false
     t.string "animal"
     t.float "price_per_day"
+    t.float "latitude"
+    t.float "longitude"
+    t.string "address"
     t.index ["user_id"], name: "index_outfits_on_user_id"
   end
 


### PR DESCRIPTION
Created the following logic for the bookings index:

- If current_user has pending booking requests for their outfits, they will see them first with the option to accept/decline.
- if current_user has accepted bookings for their outfits, they will see those too
- if current_user has sent a booking request, they will see their requested outfit. 
- If current_user has either no pending bookings, or no booking requests sent, they will just see an n/a message.

Here's an example of a current_user that has pending booking requests for their outfits - which they need to accept or decline.
They also have sent booking requests for outfits to rent - which they can see. 
![image](https://github.com/catagalan-mtl/pawsh/assets/129611938/813a3f3d-c1d8-4797-bbf3-e4d036ab5830)
